### PR TITLE
feat(docker): convert to multi-stage image with Wolfi base to improve security posture

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: generate tag
         run: |-
-            export PROJ_VERSION="1.0.0"
+            export PROJ_VERSION="1.1.0"
             echo "Project Version: $PROJ_VERSION"
             echo "TAG=$PROJ_VERSION-$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
             echo "SHORT_TAG=$PROJ_VERSION" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,20 @@
-FROM python:3-slim-buster
+# syntax=docker/dockerfile:1.7
 
-RUN pip3 install mysql-connector-python kubernetes
+FROM cgr.dev/chainguard/python:latest-dev AS builder
+
+USER root
+
+WORKDIR /build
+
+RUN pip install \
+    --no-cache-dir \
+    --prefix=/install \
+    mysql-connector-python==9.7.0 \
+    kubernetes==35.0.0
+
+# Free Python image from Chainguard: Python 3.14.4
+FROM cgr.dev/chainguard/python:latest
+
+COPY --from=builder --chown=431:431 /install /usr/
 
 USER 431


### PR DESCRIPTION
Significantly improved security posture (Docker image) by using multi-stage Docker image (with Wolfi base). Eliminates all 2 critical CVEs flagged by Grype against the `1.0.11` image (82 -> 63 findings). Total findings (flagged by Grype):
- `1.0.0`: 2 critical, 64 high, 84 medium, 25 low, 76 negligible (4 unknown)
- `1.1.0`: 0 critical, 2 high, 4 medium, 1 low, 0 negligible

Pin Python packages:
- mysql-connector-python: 9.7.0
- kubernetes: 35.0.0

Grype build info:
```bash
Application:         grype
Version:             0.112.0
BuildDate:           2026-05-01T18:14:09Z
GitCommit:           Homebrew
GitDescription:      [not provided]
Platform:            darwin/arm64
GoVersion:           go1.26.2
Compiler:            gc
Syft Version:        v1.44.0
Supported DB Schema: 6
```

Grype database status:
```bash
Schema:    v6.1.4
Built:     2026-05-04T07:20:44Z
From:      https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.4_2026-05-04T00:44:01Z_1777879244.tar.zst?checksum=sha256%3Af8865579ddd2e2e69b56d20730d5f90fb2fe38434a7f2afaf0bd1a3412ce445c
```